### PR TITLE
pin the version of hint and exceptions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ test: build
 
 
 customized-hint/hint.cabal:
-	git clone git@github.com:mvdan/hint.git customized-hint
+	git clone --branch=v0.5.2 git@github.com:mvdan/hint.git customized-hint
 
 proofs/$(WITH_GHC_IMAGE): with-ghc.docker customized-hint/hint.cabal my-program.cabal src/Main.hs
 	mkdir -p proofs

--- a/Makefile
+++ b/Makefile
@@ -51,4 +51,4 @@ clean:
 clobber: clean
 	docker rmi $(WITH_GHC_IMAGE):cache || true
 	docker rmi $(WITHOUT_GHC_IMAGE) || true
-	rm -rf my-program.tar.gz
+	rm -rf my-program.tar.gz customized-hint

--- a/my-program.cabal
+++ b/my-program.cabal
@@ -20,7 +20,7 @@ executable my-program
   -- other-extensions:    
   build-depends:       base >=4.8 && <4.9
                      , acme-dont == 1.1
-                     , hint == 0.5.1
+                     , hint == 0.5.2
   hs-source-dirs:      src
   default-language:    Haskell2010
   ld-options: -Wl,-rpath -Wl,$ORIGIN/c-libs


### PR DESCRIPTION
Fixes #1, kind of; I could pin the versions of more dependencies, but this set is good enough for now as it at least it fixes the current compilation errors.