### PR TITLE
try making paths relative, for a relocatable binary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ build: proofs/$(WITHOUT_GHC_IMAGE)
 
 test: build
 	docker rm -vf $(WITHOUT_GHC_CONTAINER) &> /dev/null || true
-	echo '()' | docker run -i --name $(WITHOUT_GHC_CONTAINER) $(WITHOUT_GHC_IMAGE) /root/my-program/my-program
+	echo '()' | docker run -i --name $(WITHOUT_GHC_CONTAINER) $(WITHOUT_GHC_IMAGE)
 
 
 customized-hint/hint.cabal:

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -23,7 +23,7 @@ interpretDon'tReturn u = do
 
 
 libdir :: String
-libdir = "/root/my-program/haskell-libs"
+libdir = "haskell-libs"
 
 main :: IO ()
 main = do

--- a/with-ghc.docker
+++ b/with-ghc.docker
@@ -27,20 +27,20 @@ RUN mkdir -p                                                               my-pr
     cp -r /opt/ghc/7.10.3/lib/ghc-7.10.3/package.conf.d/ghc-prim-*.conf    my-program/haskell-libs/package.conf.d/ && \
     cp -r /opt/ghc/7.10.3/lib/ghc-7.10.3/package.conf.d/integer-gmp-*.conf my-program/haskell-libs/package.conf.d/ && \
     cp -r .cabal-sandbox/*-packages.conf.d/acme-dont-*.conf                my-program/haskell-libs/package.conf.d/ && \
-    sed -i 's/\/opt\/ghc\/7.10.3\/lib\/ghc-7.10.3/\/root\/my-program\/haskell-libs/g' \
+    sed -i 's/\/opt\/ghc\/7.10.3\/lib\/ghc-7.10.3/haskell-libs/g' \
                                                                            my-program/haskell-libs/package.conf.d/builtin_rts.conf && \
-    sed -i 's/\/opt\/ghc\/7.10.3\/lib\/ghc-7.10.3/\/root\/my-program\/haskell-libs/g' \
+    sed -i 's/\/opt\/ghc\/7.10.3\/lib\/ghc-7.10.3/haskell-libs/g' \
                                                                            my-program/haskell-libs/package.conf.d/base-*.conf && \
-    sed -i 's/\/opt\/ghc\/7.10.3\/lib\/ghc-7.10.3/\/root\/my-program\/haskell-libs/g' \
+    sed -i 's/\/opt\/ghc\/7.10.3\/lib\/ghc-7.10.3/haskell-libs/g' \
                                                                            my-program/haskell-libs/package.conf.d/ghc-prim-*.conf && \
-    sed -i 's/\/opt\/ghc\/7.10.3\/lib\/ghc-7.10.3/\/root\/my-program\/haskell-libs/g' \
+    sed -i 's/\/opt\/ghc\/7.10.3\/lib\/ghc-7.10.3/haskell-libs/g' \
                                                                            my-program/haskell-libs/package.conf.d/integer-gmp-*.conf && \
-    sed -i 's/\/root\/.cabal-sandbox\/lib\/x86_64-linux-ghc-7.10.3/\/root\/my-program\/haskell-libs/g' \
+    sed -i 's/\/root\/.cabal-sandbox\/lib\/x86_64-linux-ghc-7.10.3/haskell-libs/g' \
                                                                            my-program/haskell-libs/package.conf.d/acme-dont-*.conf && \
     ghc-pkg --package-db=my-program/haskell-libs/package.conf.d recache && \
     cp -r /opt/ghc/7.10.3/lib/ghc-7.10.3/platformConstants                 my-program/haskell-libs/ && \
     cp -r /opt/ghc/7.10.3/lib/ghc-7.10.3/settings                          my-program/haskell-libs/ && \
-    sed -i 's/\/usr\/bin\/gcc/\/root\/my-program\/bin\/fake_gcc.sh/g'      my-program/haskell-libs/settings && \
+    sed -i 's/\/usr\/bin\/gcc/bin\/fake_gcc.sh/g'      my-program/haskell-libs/settings && \
     mkdir -p                                                               my-program/bin
 
 COPY fake_gcc.sh /root/my-program/bin/fake_gcc.sh
@@ -49,4 +49,4 @@ RUN cabal install && \
     cp .cabal-sandbox/bin/my-program my-program/ && \
     tar czvf my-program.tar.gz my-program
 
-CMD ["./my-program/my-program"]
+CMD ["cd my-program;./my-program"]

--- a/without-ghc.docker
+++ b/without-ghc.docker
@@ -7,4 +7,6 @@ COPY my-program.tar.gz /root/my-program.tar.gz
 
 RUN tar xvf my-program.tar.gz
 
-CMD ["./my-program/my-program"]
+WORKDIR /root/my-program
+
+CMD ["./my-program"]


### PR DESCRIPTION
This doesn't work from `make`:
```shell
echo '()' | docker run -i --name run-without-ghc without-ghc /root/my-program/my-program
Error: No such container: run-without-ghc
please type '()':
(\x -> (x,x)) () is:
Left (GhcException "can't load .so/.DLL for: libHSghc-prim-0.4.0.0-8TmvWUcS1U1IKHT0levwg3.so (libHSghc-prim-0.4.0.0-8TmvWUcS1U1IKHT0levwg3.so: cannot open shared object file: No such file or directory)")
and now, let's try the Prelude...
id () is:
Left (GhcException "panic! (the 'impossible' happened)\n  (GHC version 7.10.3 for x86_64-unknown-linux):\n\tDynamic linker not initialised\n\nPlease report this as a GHC bug:  http://www.haskell.org/ghc/reportabug\n")
and finally, a library from hackage.
don't (return ()) is:
GhcException "panic! (the 'impossible' happened)\n  (GHC version 7.10.3 for x86_64-unknown-linux):\n\tDynamic linker not initialised\n\nPlease report this as a GHC bug:  http://www.haskell.org/ghc/reportabug\n"
```
However it does run if I try 'by hand':
```shell
alex@teff:~/src/deploy-hint$ docker exec -t -i run-without-ghc /bin/bash
root@6dce93aaa8ec:~# ls
my-program  my-program.tar.gz
root@6dce93aaa8ec:~# cd my-program
root@6dce93aaa8ec:~/my-program# ls
bin  c-libs  haskell-libs  my-program
root@6dce93aaa8ec:~/my-program# ./my-program 
please type '()':
()
(\x -> (x,x)) () is:
Right ((),())
and now, let's try the Prelude...
id () is:
Right ()
and finally, a library from hackage.
don't (return ()) is:
()
root@6dce93aaa8ec:~/my-program#
```